### PR TITLE
add --revision flag to print current revision hash

### DIFF
--- a/cmd/pfDeploy/cli.go
+++ b/cmd/pfDeploy/cli.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/erodrigufer/pfDeploy/internal/version"
 	"github.com/urfave/cli/v2"
 )
 
@@ -19,9 +20,19 @@ func (app *application) runTUI() {
 // setupCLI, configure and initialize all commands, flags and options of
 // the TUI.
 func (app *application) setupCLI() {
+	cli.VersionFlag = &cli.BoolFlag{
+		Name:    "revision",
+		Aliases: []string{"r"},
+		Usage:   "Print the VCS revision when the binary was built (if the binary is a modified version of a commit the suffix 'dirty' will be added to the revision hash).",
+	}
+	cli.VersionPrinter = func(cCtx *cli.Context) {
+		fmt.Printf("revision=%s\n", version.GetRevision())
+	}
+
 	app.tui = &cli.App{
-		Name:  "pfDeploy",
-		Usage: "Automatically setup pf in your new deployment.",
+		Name:    "pfDeploy",
+		Version: version.GetRevision(),
+		Usage:   "Automatically setup pf in your new deployment.",
 		// This options enables short flag abbreviations to be merged into a
 		// single flag with a '-' prefix.
 		UseShortOptionHandling: true,

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,45 @@
+// version gets version information embedded during the build process in the
+// executable, e.g. revision and revision status from the VCS.
+//
+// This codebase has been modified from its original form, taken from
+// autostrada.dev aka. Alex Edwards (2022).
+package version
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+// GetRevision, returns a string with the commit hash used to build the
+// executable. If the executable was built with files with some modifications
+// related to the last commit, the suffix '-dirty' will be added to the revision
+// returned. If no revision information could be retrieved, the the method
+// returns 'unavailable'.
+func GetRevision() string {
+	var revision string
+	var modified bool
+
+	bi, ok := debug.ReadBuildInfo()
+	if ok {
+		for _, s := range bi.Settings {
+			switch s.Key {
+			case "vcs.revision":
+				revision = s.Value
+			case "vcs.modified":
+				if s.Value == "true" {
+					modified = true
+				}
+			}
+		}
+	}
+
+	if revision == "" {
+		return "unavailable"
+	}
+
+	if modified {
+		return fmt.Sprintf("%s-dirty", revision)
+	}
+
+	return revision
+}


### PR DESCRIPTION
Print the VCS revision with the `-r` or `--revision` flags. 

The revision information is embedded at build time into the executable, so it does not require the developer to be constantly upgrading the information.